### PR TITLE
using shell-executor to remove zombie processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- --compilers js:babel/register --recursive",
     "watch": "nodemon -e js,html,css --watch \"www\" --ignore \"www/js/bundle.js\" --exec \"npm run start:browser\"",
     "livereload": "livereload \"platforms/browser/www/\"",
-    "dev": "parallelshell \"npm run watch\" \"npm run livereload\"",
+    "dev": "shell-exec --colored-output \"npm run watch\" \"npm run livereload\"",
     "debug:android": "cordova build android",
     "postdebug:android": "node scripts/postdebug-android.js",
     "release:android": "cordova build android --release",
@@ -66,9 +66,9 @@
     "livereload": "^0.4.0",
     "mocha": "^2.3.4",
     "nodemon": "^1.8.1",
-    "parallelshell": "^2.0.0",
     "react-addons-test-utils": "^0.14.2",
     "redux-devtools": "^2.1.5",
+    "shell-executor": "^0.3.2",
     "skin-deep": "^0.13.0"
   }
 }


### PR DESCRIPTION
Look at this link for more details: https://www.npmjs.com/package/shell-executor

Long story short, parallelshell leaves zombie processes, and shell-executor will give a command to delete zombie processes if there are any left behind... just in case!