### PR TITLE
Publish drawer

### DIFF
--- a/test/js/components/ac-drawer.spec.js
+++ b/test/js/components/ac-drawer.spec.js
@@ -1,0 +1,32 @@
+/*eslint-disable no-unused-vars*/
+/*global describe before after beforeEach afterEach it $*/
+import chai, { expect } from 'chai';
+import sd from 'skin-deep';
+
+import React from 'react';
+import ReactDom from 'react-dom';
+import { ACDrawer } from '../../../www/js/components/ac-drawer';
+/*eslint-enable no-unused-vars*/
+
+describe( '<ACDrawer />', function() {
+  it( 'should be closed by default', function() {
+    const tree = sd.shallowRender( (
+      <ACDrawer page='New Page' account={ {login: {}} } />
+    ) );
+
+    const instance = tree.getMountedInstance();
+    const vdom = tree.getRenderOutput();
+
+    expect(instance.state.open).to.be.false;
+  } );
+  it( 'should make the title the page property', function() {
+    const tree = sd.shallowRender( (
+      <ACDrawer page='New Page' account={ {login: {}} } />
+    ) );
+
+    const appBar = tree.dive(['AppBar']);
+    const appBarInstance = appBar.getMountedInstance();
+
+    expect(appBarInstance.props.title).to.be.equal('New Page');
+  } );
+} );

--- a/test/js/components/ac-drawer.spec.js
+++ b/test/js/components/ac-drawer.spec.js
@@ -15,7 +15,6 @@ describe( '<ACDrawer />', function() {
     ) );
 
     const instance = tree.getMountedInstance();
-    const vdom = tree.getRenderOutput();
 
     expect(instance.state.open).to.be.false;
   } );

--- a/www/js/components/ac-drawer.js
+++ b/www/js/components/ac-drawer.js
@@ -49,7 +49,11 @@ export class ACDrawer extends Component {
     }, {
       link: 'download-track',
       title: 'Download Track',
-      icon: 'cloud_download'
+      icon: 'timeline'
+    }, {
+      link: '/',
+      title: 'Publish',
+      icon: 'cloud_upload'
     }, {
       link: 'settings',
       title: 'Settings',

--- a/www/js/containers/download-track-page.js
+++ b/www/js/containers/download-track-page.js
@@ -1,6 +1,7 @@
 /*eslint-disable no-unused-vars*/
 import React, { Component } from 'react';
 import { RaisedButton, FontIcon, Card, CardMedia, CardTitle, CardActions, CardText, LinearProgress } from 'material-ui';
+import DeviceStorage from '../components/device-storage';
 /*eslint-enable no-unused-vars*/
 
 import { connect } from 'react-redux';


### PR DESCRIPTION
fixes a small bug in download track page,
creates simple tests for ac-drawer
adds publish as an item in the drawer.

![image](https://cloud.githubusercontent.com/assets/326557/13730346/e8c7d02c-e922-11e5-87d5-0dcfb0b2beb9.png)
